### PR TITLE
support docker compose v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /logs/
 /log/
 /exment/
+/exment-boilerplate/

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,40 @@
 mysql-up:
-	docker-compose -f docker-compose.yml -f docker-compose.mysql.yml up -d
+	docker compose -f docker-compose.yml -f docker-compose.mysql.yml up -d
 mariadb-up:
-	docker-compose -f docker-compose.yml -f docker-compose.mariadb.yml up -d
+	docker compose -f docker-compose.yml -f docker-compose.mariadb.yml up -d
 sqlsrv-up:
-	docker-compose -f docker-compose.yml -f docker-compose.sqlsrv.yml up -d
+	docker compose -f docker-compose.yml -f docker-compose.sqlsrv.yml up -d
 php:
-	docker-compose  -f docker-compose.yml exec php bash
+	docker compose  -f docker-compose.yml exec php bash
 down:
-	docker-compose  -f docker-compose.yml -f docker-compose.mysql.yml -f docker-compose.sqlsrv.yml -f docker-compose.mariadb.yml  down
+	docker compose  -f docker-compose.yml -f docker-compose.mysql.yml -f docker-compose.sqlsrv.yml -f docker-compose.mariadb.yml  down
 destroy:
-	docker-compose  -f docker-compose.yml -f docker-compose.mysql.yml -f docker-compose.sqlsrv.yml -f docker-compose.mariadb.yml down --rmi all --volumes --remove-orphans
+	docker compose  -f docker-compose.yml -f docker-compose.mysql.yml -f docker-compose.sqlsrv.yml -f docker-compose.mariadb.yml down --rmi all --volumes --remove-orphans
 ps:
-	docker-compose  -f docker-compose.yml -f docker-compose.mysql.yml -f docker-compose.sqlsrv.yml -f docker-compose.mariadb.yml ps
+	docker compose  -f docker-compose.yml -f docker-compose.mysql.yml -f docker-compose.sqlsrv.yml -f docker-compose.mariadb.yml ps
 logs:
-	docker-compose  -f docker-compose.yml -f docker-compose.mysql.yml -f docker-compose.sqlsrv.yml -f docker-compose.mariadb.yml logs
+	docker compose  -f docker-compose.yml -f docker-compose.mysql.yml -f docker-compose.sqlsrv.yml -f docker-compose.mariadb.yml logs
 exec:
-	docker-compose  -f docker-compose.yml -f docker-compose.mysql.yml -f docker-compose.sqlsrv.yml -f docker-compose.mariadb.yml exec
+	docker compose  -f docker-compose.yml -f docker-compose.mysql.yml -f docker-compose.sqlsrv.yml -f docker-compose.mariadb.yml exec
 logs-watch:
-	docker-compose logs --follow
+	docker compose logs --follow
 mysql-init:
 	@make down
 	@make mysql-up
-	docker-compose -f docker-compose.yml exec -T php chown www-data:www-data -R .
-	docker-compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=600 php composer install
-	docker-compose -f docker-compose.yml exec -T php cp .env.mysql .env
-	docker-compose -f docker-compose.yml exec -T php php artisan key:generate
-	docker-compose -f docker-compose.yml exec -T php php artisan passport:key
+	docker compose -f docker-compose.yml exec -T php chown www-data:www-data -R .
+	docker compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=600 php composer install
+	docker compose -f docker-compose.yml exec -T php cp .env.mysql .env
+	docker compose -f docker-compose.yml exec -T php php artisan key:generate
+	docker compose -f docker-compose.yml exec -T php php artisan passport:key
 
 mariadb-init:
 	@make down
 	@make mariadb-up
-	docker-compose -f docker-compose.yml exec -T php chown www-data:www-data -R .
-	docker-compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=600 php composer install
-	docker-compose -f docker-compose.yml exec -T php cp .env.mariadb .env
-	docker-compose -f docker-compose.yml exec -T php php artisan key:generate
-	docker-compose -f docker-compose.yml exec -T php php artisan passport:key
+	docker compose -f docker-compose.yml exec -T php chown www-data:www-data -R .
+	docker compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=600 php composer install
+	docker compose -f docker-compose.yml exec -T php cp .env.mariadb .env
+	docker compose -f docker-compose.yml exec -T php php artisan key:generate
+	docker compose -f docker-compose.yml exec -T php php artisan passport:key
 
 sqlsrv-init:
 	@make down
@@ -42,11 +42,11 @@ sqlsrv-init:
 	@make ps
 	@make logs
 	sleep 30
-	docker-compose -f docker-compose.sqlsrv.yml run -T sqlsrv-create-db
+	docker compose -f docker-compose.sqlsrv.yml run -T sqlsrv-create-db
 	@make ps
 	@make logs
-	docker-compose -f docker-compose.yml exec -T php chown www-data:www-data -R .
-	docker-compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=600 php composer install
-	docker-compose -f docker-compose.yml exec -T php cp .env.sqlsrv .env
-	docker-compose -f docker-compose.yml exec -T php php artisan key:generate
-	docker-compose -f docker-compose.yml exec -T php php artisan passport:key
+	docker compose -f docker-compose.yml exec -T php chown www-data:www-data -R .
+	docker compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=600 php composer install
+	docker compose -f docker-compose.yml exec -T php cp .env.sqlsrv .env
+	docker compose -f docker-compose.yml exec -T php php artisan key:generate
+	docker compose -f docker-compose.yml exec -T php php artisan passport:key

--- a/README.md
+++ b/README.md
@@ -1,8 +1,52 @@
 # Docker Exment
 
-## このイメージについて
-ExmentのDockerイメージです。
+This is a repository for building an environment for boilerplate to launch exment in each database.
+
+## About this image
+Docker image of Exment.
+https://github.com/exceedone/exment
+
+## How to use images
+
+First clone the repository.
+https://github.com/exceedone/exment-boilerplate
+
+### Building a MySQL environment
+
+```bash
+$ make mysql-init
+```
+
+### Setting up a MySQL environment
+
+```bash
+$ make mysql-up
+```
+
+### Building a MariaDB environment
+
+```bash
+$ make maridb-init
+```
+
+### Setting up a MariaDB environment
+
+```bash
+$ make maridb-init
+```
+
+### Building a SQL Server environment
+
+```bash
+$ make sqlsrv-init
+```
+
+### Setting up a SQL Server environment
+
+```bash
+$ make sqlsrv-up
+```
 
 
-## イメージの使用方法
+
 

--- a/docker-compose.balancer.yml
+++ b/docker-compose.balancer.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   balancer:
     image: jwilder/nginx-proxy

--- a/docker-compose.https-portal.yml
+++ b/docker-compose.https-portal.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   https-portal:
     image: steveltn/https-portal:1

--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   mariadb:
     image: mariadb:10.4

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   mysql:
     image: mysql/mysql-server:5.7

--- a/docker-compose.phpmyadmin.yml
+++ b/docker-compose.phpmyadmin.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
  phpmyadmin:
     image: phpmyadmin/phpmyadmin:latest

--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   redis:
     image: "redis:latest"

--- a/docker-compose.sqlsrv.yml
+++ b/docker-compose.sqlsrv.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   sqlsrv:
     build: docker/sqlsrv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     image: nginx:latest


### PR DESCRIPTION
下記の対応をしました。

* docker-compose V2対応
* READMEにこのリポジトリの使い方を記載
* .gitignoreにboilerplateのディレクトリを追加

The following actions were taken

* docker-compose V2 support
* README describes how to use this repository
* Added boilerplate directory to .gitignore