### PR TITLE
Change MySQL image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ mysql-init:
 	docker compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=600 php composer install
 	docker compose -f docker-compose.yml exec -T php cp .env.mysql .env
 	docker compose -f docker-compose.yml exec -T php php artisan key:generate
-	docker compose -f docker-compose.yml exec -T php php artisan passport:key
+	docker compose -f docker-compose.yml exec -T php php artisan passport:key --force
 
 mariadb-init:
 	@make down
@@ -34,7 +34,7 @@ mariadb-init:
 	docker compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=600 php composer install
 	docker compose -f docker-compose.yml exec -T php cp .env.mariadb .env
 	docker compose -f docker-compose.yml exec -T php php artisan key:generate
-	docker compose -f docker-compose.yml exec -T php php artisan passport:key
+	docker compose -f docker-compose.yml exec -T php php artisan passport:key --force
 
 sqlsrv-init:
 	@make down
@@ -49,4 +49,4 @@ sqlsrv-init:
 	docker compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=600 php composer install
 	docker compose -f docker-compose.yml exec -T php cp .env.sqlsrv .env
 	docker compose -f docker-compose.yml exec -T php php artisan key:generate
-	docker compose -f docker-compose.yml exec -T php php artisan passport:key
+	docker compose -f docker-compose.yml exec -T php php artisan passport:key --force

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql/mysql-server:8.0
+    image: mysql:8.0
     ports:
       - ${EXMENT_DOCKER_MYSQL_PORT-3306}:3306
     volumes:

--- a/docker/mysql/volumes/my.cnf
+++ b/docker/mysql/volumes/my.cnf
@@ -22,7 +22,6 @@
 # this will increase compatibility with older clients. For background, see:
 # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
 # default-authentication-plugin=mysql_native_password
-skip-host-cache
 skip-name-resolve
 datadir=/var/lib/mysql
 socket=/var/lib/mysql/mysql.sock


### PR DESCRIPTION
## implement

将来MySQLのバージョンをあげることを見越してmysql/mysql-serverではなくoracle officialのイメージに変更しました。


Change to the Oracle Official image instead of mysql/mysql-server, in anticipation of future MySQL version upgrades.


## supplement

mysql/mysql-serverはすでに新しいバージョンをサポートしていません。


The mysql/mysql-server image no longer supports newer versions.

https://hub.docker.com/r/mysql/mysql-server/tags