### PR TITLE
update SQL Server driver installation for modern Docker environment

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -8,11 +8,11 @@ RUN apt-get update && apt-get install -y git wget gnupg vim unzip libxml2-dev li
   && apt-get clean
 
 # install pre sql server driver
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-  && curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \
+RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
+  && echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" > /etc/apt/sources.list.d/msprod.list \
   && apt-get update \
-  && apt-get install -y unixodbc-dev=2.3.7 unixodbc=2.3.7 odbcinst1debian2=2.3.7 odbcinst=2.3.7 libgssapi-krb5-2 \
-  && ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools
+  && apt-get install -y unixodbc-dev libgssapi-krb5-2 \
+  && ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18
 
 # install sql server driver
 RUN pecl install sqlsrv && pecl install pdo_sqlsrv && docker-php-ext-enable sqlsrv && docker-php-ext-enable pdo_sqlsrv


### PR DESCRIPTION
fix blow problems.

  - Replace deprecated apt-key with gpg --dearmor for Microsoft package signing
  - Switch from Ubuntu 20.04 to Debian 12 (bookworm) repository for better compatibility
  - Update to msodbcsql18 and mssql-tools18 for latest SQL Server support
  - Simplify unixodbc package dependencies to avoid version conflicts
  - Ensure compatibility with PHP 8.2 FPM on ARM64 architecture