### PR TITLE
fix: address structural issues in Docker config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ $ make mysql-up
 ### Building a MariaDB environment
 
 ```bash
-$ make maridb-init
+$ make mariadb-init
 ```
 
 ### Setting up a MariaDB environment
 
 ```bash
-$ make maridb-init
+$ make mariadb-up
 ```
 
 ### Building a SQL Server environment

--- a/docker-compose.https-portal.yml
+++ b/docker-compose.https-portal.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - web
     volumes:
-      - .docker/https-portal/volumes/default.ssl.conf.erb:/var/lib/nginx-conf/${EXMENT_DOCKER_FRONT_DOMAIN-localhost}.conf.erb:ro
+      - ./docker/https-portal/volumes/default.ssl.conf.erb:/var/lib/nginx-conf/${EXMENT_DOCKER_FRONT_DOMAIN-localhost}.conf.erb:ro
     environment:
       STAGE: ${EXMENT_DOCKER_HTTPS_STAGE-staging}
       DOMAINS: '${EXMENT_DOCKER_FRONT_DOMAIN-localhost} -> ${EXMENT_DOCKER_HTTPS_TARGET_URL-http://web:80}'

--- a/docker-compose.sqlsrv.yml
+++ b/docker-compose.sqlsrv.yml
@@ -11,7 +11,7 @@ services:
       SA_PASSWORD: ${EXMENT_DOCKER_SQLSRV_ROOT_PASSWORD}
       MSSQL_PID: ${EXMENT_DOCKER_SQLSRV_PID-Express}
       SQLSRV_COLLATION: Japanese_CI_AS
-      # - SQLSRV_LCID: 1041
+      # SQLSRV_LCID: 1041
 
   sqlsrv-create-db:
     image: tsgkadot/mssql-tools

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -20,5 +20,4 @@ RUN pecl install sqlsrv-5.12.0 && pecl install pdo_sqlsrv-5.12.0 && docker-php-e
 # install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-COPY .env /var/www/exment/.env
 WORKDIR /var/www/exment


### PR DESCRIPTION
## 概要
Docker 構成ファイルとドキュメントの構造的な問題点を修正します。

## 変更内容

### セキュリティ: `.env` のイメージ焼き込みを除去 (`docker/php/Dockerfile`)
- `COPY .env /var/www/exment/.env` を削除
- `docker-compose.yml` の volume mount (`./exment-boilerplate:/var/www/exment`) が `/var/www/exment` を上書きするため、この `COPY` は実行時に意味がなかったため削除
- `.env` に含まれる DB パスワード等の機密情報がイメージレイヤーに残るリスクを排除しました

### バグ修正: https-portal の volume パス (`docker-compose.https-portal.yml`)
- `.docker/https-portal/volumes/...` → `./docker/https-portal/volumes/...`
- `.docker/` は存在しない隠しディレクトリを参照しており、https-portal 起動時にマウントが失敗する

### YAML 整合性: sqlsrv コメント修正 (`docker-compose.sqlsrv.yml`)
- `# - SQLSRV_LCID: 1041` → `# SQLSRV_LCID: 1041`
- `environment` は dict 形式で記述されているが、コメント内に list 形式の `- ` が残っていた
- このまま誤ってアンコメントすると YAML パースエラーになる

### ドキュメント: README.md の typo 修正
- `make maridb-init` → `make mariadb-init` (2箇所)
- MariaDB「Setting up」セクションのコマンドが `maridb-init` → `mariadb-up` に修正
