### PR TITLE
feat: add PCOV-based unit/feature coverage tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,33 @@ sqlsrv-init:
 	docker compose -f docker-compose.yml exec -T php cp .env.sqlsrv .env
 	docker compose -f docker-compose.yml exec -T php php artisan key:generate
 	docker compose -f docker-compose.yml exec -T php php artisan passport:key --force
+
+# --- Coverage targets -------------------------------------------------------
+# COV_DIR: where per-suite *.cov dumps land (inside the container path).
+COV_DIR=storage/logs/coverage
+EXMENT_TESTS=./vendor/exceedone/exment/tests
+
+# Run unit tests with --coverage-php so the merge step can pick them up.
+test-coverage-unit:
+	docker compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=0 php \
+	  bash -c "mkdir -p $(COV_DIR) && php artisan exment:inittest --yes && php -d memory_limit=1024M vendor/bin/phpunit $(EXMENT_TESTS)/Unit --coverage-php $(COV_DIR)/unit.cov"
+
+# Run feature tests with --coverage-php.
+test-coverage-feature:
+	docker compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=0 php \
+	  bash -c "mkdir -p $(COV_DIR) && php artisan exment:inittest --yes && php -d memory_limit=1024M vendor/bin/phpunit $(EXMENT_TESTS)/Feature --coverage-php $(COV_DIR)/feature.cov"
+
+# Merge .cov files and emit clover/html/text reports under $(COV_DIR)/merged/.
+test-coverage-merge:
+	docker compose -f docker-compose.yml exec -T php php -d memory_limit=2048M /usr/local/bin/merge-coverage.php
+
+# One-shot: unit + feature + merge.
+test-coverage:
+	@make test-coverage-unit
+	@make test-coverage-feature
+	@make test-coverage-merge
+
+# Browser tests segfault under PCOV; run them with pcov.enabled=0 and no coverage.
+test-browser:
+	docker compose -f docker-compose.yml exec -T -e COMPOSER_PROCESS_TIMEOUT=0 php \
+	  bash -c "php artisan exment:inittest --yes && php -d pcov.enabled=0 vendor/bin/phpunit $(EXMENT_TESTS)/Browser --no-coverage"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - ./exment-boilerplate:/var/www/exment
       - ./docker/php/volumes/php.ini:/usr/local/etc/php/php.ini
       - ./docker/php/volumes/mysql-client.cnf:/etc/mysql/conf.d/client.cnf
+      - ./docker/php/volumes/merge-coverage.php:/usr/local/bin/merge-coverage.php:ro
     env_file: .env
     networks:
       - exment-network

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -17,6 +17,9 @@ RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor
 # install sql server driver
 RUN pecl install sqlsrv-5.12.0 && pecl install pdo_sqlsrv-5.12.0 && docker-php-ext-enable sqlsrv && docker-php-ext-enable pdo_sqlsrv
 
+# install PCOV for fast code coverage (disabled by default; enabled per-run via -d pcov.enabled=1)
+RUN pecl install pcov && docker-php-ext-enable pcov
+
 # install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/docker/php/volumes/merge-coverage.php
+++ b/docker/php/volumes/merge-coverage.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Report\Clover;
+use SebastianBergmann\CodeCoverage\Report\Html\Facade as HtmlFacade;
+use SebastianBergmann\CodeCoverage\Report\Text;
+use SebastianBergmann\CodeCoverage\Report\Thresholds;
+
+$root = '/var/www/exment';
+require $root . '/vendor/autoload.php';
+
+$covDir = $argv[1] ?? $root . '/storage/logs/coverage';
+$outDir = $argv[2] ?? $covDir . '/merged';
+
+if (!is_dir($outDir)) {
+    mkdir($outDir, 0777, true);
+}
+
+$files = glob($covDir . '/*.cov') ?: [];
+if (!$files) {
+    fwrite(STDERR, "no .cov files found in {$covDir}\n");
+    exit(1);
+}
+
+/** @var CodeCoverage|null $merged */
+$merged = null;
+foreach ($files as $file) {
+    fwrite(STDERR, "loading {$file}\n");
+    /** @var CodeCoverage $cov */
+    $cov = require $file;
+
+    if ($merged === null) {
+        $merged = $cov;
+        continue;
+    }
+    $merged->merge($cov);
+}
+
+if ($merged === null) {
+    fwrite(STDERR, "no coverage loaded\n");
+    exit(1);
+}
+
+(new Clover())->process($merged, $outDir . '/clover.xml');
+(new HtmlFacade())->process($merged, $outDir . '/html');
+
+$summary = (new Text(Thresholds::default(), false, true))->process($merged, false);
+file_put_contents($outDir . '/summary.txt', $summary);
+
+echo $summary;
+echo "\n";
+echo "merged clover: {$outDir}/clover.xml\n";
+echo "merged html:   {$outDir}/html/index.html\n";

--- a/docker/php/volumes/php.ini
+++ b/docker/php/volumes/php.ini
@@ -4,3 +4,7 @@ post_max_size=10M
 upload_max_filesize=10M
 memory_limit=512M
 max_execution_time=600
+
+; PCOV: enabled to collect coverage; set to 0 for runs that don't need coverage
+pcov.enabled=1
+pcov.directory=/var/www/exment


### PR DESCRIPTION
  ## Summary

  This PR brings covering coverage tooling for PHP container.

  ### Code coverage tooling (new)
  - Install PCOV in the PHP image for fast coverage collection (avoids
    the 5–10x slowdown of Xdebug)
  - `docker/php/volumes/merge-coverage.php`: merge per-suite `.cov`
    dumps into clover / html / text reports
  - New Makefile targets:
    - `make test-coverage-unit` / `test-coverage-feature` / `test-coverage-merge`
    - `make test-coverage` (one-shot: unit → feature → merge)
    - `make test-browser` (runs browser tests with `pcov.enabled=0` to
      avoid PCOV segfaults on BrowserKit)
  - `pcov.enabled=1` and `pcov.directory` set in `php.ini`

  ## Summary

コードのカバレッジ計測の整備のためにPHPのコンテナにコードカバレッジ計測用の設定を追加しました。

  ### コードカバレッジ計測（新規）
  - PHP イメージに PCOV を導入（Xdebug 比で 5〜10 倍高速にカバレッジ
    を取得可能）
  - `docker/php/volumes/merge-coverage.php`: suite ごとの `.cov` ダンプ
    を clover / html / text レポートに統合するスクリプト
  - Makefile に以下のターゲットを追加:
    - `make test-coverage-unit` / `test-coverage-feature` / `test-coverage-merge`
    - `make test-coverage`（unit → feature → merge を一括実行）
    - `make test-browser`（BrowserKit と PCOV の組み合わせで発生する
      segfault を避けるため `pcov.enabled=0` で実行）
  - `php.ini` に `pcov.enabled=1` と `pcov.directory` を設定

